### PR TITLE
Fix: source maps

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A simple utility for composing two or more react refs into a single callback ref.",
   "main": "composeRefs.js",
   "scripts": {
-    "build": "rm -rf dist/ && npm test && npm run compile && cp LICENSE package.json README.md dist/",
+    "build": "rm -rf dist/ && npm test && npm run compile && cp LICENSE package.json README.md composeRefs.ts dist/",
     "compile": "tsc --project .",
     "prepublishOnly": "echo 'Run \\'npm run publish-package\\' instead' && exit 1",
     "publish-package": "git push && git push --tags && npm run build && npm publish --access=public --ignore-scripts dist",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
+    "sourceRoot": ".",
     "outDir": "./dist",
 
     "strict": true,


### PR DESCRIPTION
Sourcemaps were pointing to `../composeRefs.ts` but only the dist folder will be published, causing that it will search for that file in the wrong folder. This PR should fix the sourcemaps